### PR TITLE
UserReponse에 userId 필드 추가 (마이페이지에서 userId 사용)

### DIFF
--- a/src/main/java/com/ucamp/project/dto/UserResponse.java
+++ b/src/main/java/com/ucamp/project/dto/UserResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Data
 @Builder
 public class UserResponse {
+    private Long userId;
     private String nickname;
     private String email;
     private Long jobId;
@@ -24,10 +25,11 @@ public class UserResponse {
 
 
     // 관리자 페이지에서 유저 전체 조회용 생성자
-    public UserResponse(String nickname, String email, Long jobId, String jobName,
+    public UserResponse(Long userId, String nickname, String email, Long jobId, String jobName,
                         String passStatus, LocalDateTime createdAt, String role,
                         String simulationStatus, LocalDateTime simulationCompletedAt,
                         String certStatus, LocalDateTime certReqDate, LocalDateTime certTrmtDate) {
+        this.userId = userId;
         this.nickname = nickname;
         this.email = email;
         this.jobId = jobId;

--- a/src/main/java/com/ucamp/project/repository/UserRepository.java
+++ b/src/main/java/com/ucamp/project/repository/UserRepository.java
@@ -20,6 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("""
         SELECT new com.ucamp.project.dto.UserResponse(
+            u.userId,
             u.nickname,
             u.email,
             j.jobId,


### PR DESCRIPTION
<!--
    Pull Request type
    - Feat : 새로운 기능이 필요한 경우
    - Fix : 버그 수정
    - Refactor : 기능은 추가하지 않고 코드 및 로직 개선
    - Docs : README 혹은 로직에 대한 주석을 추가하는 경우
    - Chore : 빌드 파일이나 세팅, 패키지 추가
-->

## Issue Number

- Resolves #27 

## Description

- 마이페이지에서 userId 활용하기 위해, DTO인 UserResponse에 userId 추가.

## Check List

- [ ] PR 제목을 커밋 규칙에 맞게 작성
- [ ] PR에 해당되는 Issue를 연결 완료
- [ ] 적절한 라벨 설정
- [ ] 작업한 사람 모두를 Assign
- [ ] Code Review 요청 (Reviewer 등록)
- [ ] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot